### PR TITLE
Add OCI oss support in Build/Core/Cert - JAPACCOE-2830 - Part I

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node('build-slave') {
                 build_tag = branch_name + "_" + commit_hash
                 println(ANSI_BOLD + ANSI_YELLOW + "github_release_tag not specified, using the latest commit hash: " + commit_hash + ANSI_NORMAL)
             } else {
-		println(ANSI_BOLD + "found release tag / branch, checking out: " params.github_release_tag + ANSI_NORMAL)    
+		println(ANSI_BOLD + "found release tag / branch, checking out: " + params.github_release_tag + ANSI_NORMAL)    
                 def scmVars = checkout scm
                 checkout scm: [$class: 'GitSCM', branches: [[name: "refs/tags/$params.github_release_tag"]], userRemoteConfigs: [[url: scmVars.GIT_URL]]]
                 build_tag = params.github_release_tag

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ node('build-slave') {
 		println(ANSI_BOLD + "found release tag / branch, checking out: " + params.github_release_tag + ANSI_NORMAL)    
                 def scmVars = checkout scm
 		// need to modify
-		checkout scm: [$class: 'GitSCM', branches: [[name: "refs/$params.github_release_tag"]], userRemoteConfigs: [[url: scmVars.GIT_URL]]]    
+		checkout scm: [$class: 'GitSCM', branches: [[name: "*/$params.github_release_tag"]], userRemoteConfigs: [[url: scmVars.GIT_URL]]]    
                 // checkout scm: [$class: 'GitSCM', branches: [[name: "refs/tags/$params.github_release_tag"]], userRemoteConfigs: [[url: scmVars.GIT_URL]]]
                 build_tag = params.github_release_tag
                 println(ANSI_BOLD + ANSI_YELLOW + "github_release_tag specified, building from tag: " + params.github_release_tag + ANSI_NORMAL)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,9 @@ node('build-slave') {
             } else {
 		println(ANSI_BOLD + "found release tag / branch, checking out: " + params.github_release_tag + ANSI_NORMAL)    
                 def scmVars = checkout scm
-                checkout scm: [$class: 'GitSCM', branches: [[name: "refs/tags/$params.github_release_tag"]], userRemoteConfigs: [[url: scmVars.GIT_URL]]]
+		// need to modify
+		checkout scm: [$class: 'GitSCM', branches: [[name: "refs/$params.github_release_tag"]], userRemoteConfigs: [[url: scmVars.GIT_URL]]]    
+                // checkout scm: [$class: 'GitSCM', branches: [[name: "refs/tags/$params.github_release_tag"]], userRemoteConfigs: [[url: scmVars.GIT_URL]]]
                 build_tag = params.github_release_tag
                 println(ANSI_BOLD + ANSI_YELLOW + "github_release_tag specified, building from tag: " + params.github_release_tag + ANSI_NORMAL)
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,22 +14,25 @@ node('build-slave') {
                     error 'Please resolve the errors and rerun..'
                 } else
                     println(ANSI_BOLD + ANSI_GREEN + "Found environment variable named hub_org with value as: " + hub_org + ANSI_NORMAL)
-            }
+                }
             cleanWs()
             if (params.github_release_tag == "") {
+		println(ANSI_BOLD + "no release tag / branch, checking out lastest commit" + ANSI_NORMAL)    
                 checkout scm
                 commit_hash = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
                 branch_name = sh(script: 'git name-rev --name-only HEAD | rev | cut -d "/" -f1| rev', returnStdout: true).trim()
                 build_tag = branch_name + "_" + commit_hash
                 println(ANSI_BOLD + ANSI_YELLOW + "github_release_tag not specified, using the latest commit hash: " + commit_hash + ANSI_NORMAL)
             } else {
+		println(ANSI_BOLD + "found release tag / branch, checking out: " params.github_release_tag + ANSI_NORMAL)    
                 def scmVars = checkout scm
                 checkout scm: [$class: 'GitSCM', branches: [[name: "refs/tags/$params.github_release_tag"]], userRemoteConfigs: [[url: scmVars.GIT_URL]]]
                 build_tag = params.github_release_tag
                 println(ANSI_BOLD + ANSI_YELLOW + "github_release_tag specified, building from tag: " + params.github_release_tag + ANSI_NORMAL)
             }
             echo "build_tag: " + build_tag
-
+	    println(ANSI_BOLD + "checking folder contains with ls" + ANSI_NORMAL)	  
+            sh("ls")
             stage('Build') {
 		        currentDir = sh(returnStdout: true, script: 'pwd').trim()
                 env.NODE_ENV = "build"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ node('build-slave') {
 	
 		        sh "cd $currentDir"
 		        // Build the dependencies for sunbird user-org service
-                sh 'mvn clean install'
+                sh 'mvn clean install -DskipTests'
             }
 
             stage('Package') {

--- a/all-actors/src/main/java/org/sunbird/CertsConstant.java
+++ b/all-actors/src/main/java/org/sunbird/CertsConstant.java
@@ -180,6 +180,18 @@ public class CertsConstant {
         return getPropertyFromEnv(JsonKey.PRIVATE_CLOUD_STORAGE_KEY);
     }
 
+    public String getOciStorageSecret() {
+        return getPropertyFromEnv(JsonKey.PRIVATE_CLOUD_STORAGE_SECRET);
+    }
+
+    public String getOciStorageKey() {
+        return getPropertyFromEnv(JsonKey.PRIVATE_CLOUD_STORAGE_KEY);
+    }
+
+    public String getOciStorageEndpoint() {
+        return getPropertyFromEnv(JsonKey.CLOUD_STORAGE_ENDPOINT);
+    }
+
     public String getSignatoryExtensionUrl() {
         return String.format("%s/%s/%s", BASE_PATH, SIGNATORY_EXTENSION, "context.json");
     }

--- a/all-actors/src/main/java/org/sunbird/cert/actor/CertificateGeneratorActor.java
+++ b/all-actors/src/main/java/org/sunbird/cert/actor/CertificateGeneratorActor.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.sunbird.incredible.CertificateGenerator;
 import org.sunbird.incredible.UrlManager;
 import org.sunbird.incredible.processor.CertModel;
@@ -103,7 +104,28 @@ public class CertificateGeneratorActor extends BaseActor {
 
 
     private BaseStorageService getStorageService() {
-        StorageConfig storageConfig = new StorageConfig(certVar.getCloudStorageType(), certVar.getAzureStorageKey(), certVar.getAzureStorageSecret());
+        StorageConfig storageConfig;
+        String storageKey;
+        String storageSecret;
+        scala.Option<String> storageEndpoint;
+        scala.Option<String> storageRegion;
+        if (StringUtils.equalsIgnoreCase(certVar.getCloudStorageType(), "azure")) {
+            storageKey = certVar.getAzureStorageKey();
+            storageSecret = certVar.getAzureStorageSecret();
+            storageEndpoint = scala.Option.apply("");
+            storageRegion = scala.Option.apply("");
+        } else if (StringUtils.equalsIgnoreCase(certVar.getCloudStorageType(), "oci")){
+            storageKey = certVar.getOciStorageKey();
+            storageSecret = certVar.getOciStorageSecret();
+            storageEndpoint = scala.Option.apply(certVar.getOciStorageEndpoint());
+            storageRegion = scala.Option.apply("");
+        } else {
+            storageKey = "";
+            storageSecret = "";
+            storageEndpoint = scala.Option.apply("");
+            storageRegion = scala.Option.apply("");
+        }
+        storageConfig = new StorageConfig(certVar.getCloudStorageType(), storageKey, storageSecret,storageEndpoint,storageRegion);
         logger.info(null, "CertificateGeneratorActor:getStorageService:storage object formed: {}" ,storageConfig.toString());
         return StorageServiceFactory.getStorageService(storageConfig);
     }

--- a/cert-processor/pom.xml
+++ b/cert-processor/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.sunbird</groupId>
-            <artifactId>cloud-store-sdk_2.12</artifactId>
+            <artifactId>cloud-store-sdk_2.11</artifactId>
             <version>1.4.6</version>
             <exclusions>
                 <exclusion>
@@ -108,10 +108,10 @@
             <name>iText Repository - releases</name>
             <url>https://repo.itextsupport.com/releases</url>
         </repository>
-        <repository>
+        <!-- <repository>
             <id>cloud-store</id>
             <url>https://oss.sonatype.org/content/repositories/orgsunbird-1144</url>
-        </repository>
+        </repository> -->
     </repositories>
     <build>
         <plugins>

--- a/cert-processor/pom.xml
+++ b/cert-processor/pom.xml
@@ -108,11 +108,6 @@
             <name>iText Repository - releases</name>
             <url>https://repo.itextsupport.com/releases</url>
         </repository>
-        <!-- This might cause problem -->
-        <repository>
-            <id>cloud-store</id>
-            <url>https://oss.sonatype.org/content/repositories/orgsunbird-1144</url>
-        </repository>
     </repositories>
     <build>
         <plugins>

--- a/cert-processor/pom.xml
+++ b/cert-processor/pom.xml
@@ -56,8 +56,8 @@
         </dependency>
         <dependency>
             <groupId>org.sunbird</groupId>
-            <artifactId>cloud-store-sdk</artifactId>
-            <version>1.4.0</version>
+            <artifactId>cloud-store-sdk_2.12</artifactId>
+            <version>1.4.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -107,6 +107,10 @@
             <id>itext</id>
             <name>iText Repository - releases</name>
             <url>https://repo.itextsupport.com/releases</url>
+        </repository>
+        <repository>
+            <id>cloud-store</id>
+            <url>https://oss.sonatype.org/content/repositories/orgsunbird-1144</url>
         </repository>
     </repositories>
     <build>

--- a/cert-processor/pom.xml
+++ b/cert-processor/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.sunbird</groupId>
-            <artifactId>cloud-store-sdk_2.12</artifactId>
+            <artifactId>cloud-store-sdk_2.11</artifactId>
             <version>1.4.6</version>
             <exclusions>
                 <exclusion>

--- a/cert-processor/pom.xml
+++ b/cert-processor/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.sunbird</groupId>
-            <artifactId>cloud-store-sdk_2.11</artifactId>
+            <artifactId>cloud-store-sdk_2.12</artifactId>
             <version>1.4.6</version>
             <exclusions>
                 <exclusion>
@@ -109,10 +109,10 @@
             <url>https://repo.itextsupport.com/releases</url>
         </repository>
         <!-- This might cause problem -->
-        <!-- <repository>
+        <repository>
             <id>cloud-store</id>
             <url>https://oss.sonatype.org/content/repositories/orgsunbird-1144</url>
-        </repository> -->
+        </repository>
     </repositories>
     <build>
         <plugins>

--- a/cert-processor/pom.xml
+++ b/cert-processor/pom.xml
@@ -108,6 +108,7 @@
             <name>iText Repository - releases</name>
             <url>https://repo.itextsupport.com/releases</url>
         </repository>
+        <!-- This might cause problem -->
         <!-- <repository>
             <id>cloud-store</id>
             <url>https://oss.sonatype.org/content/repositories/orgsunbird-1144</url>

--- a/cert-processor/src/main/java/org/sunbird/incredible/processor/JsonKey.java
+++ b/cert-processor/src/main/java/org/sunbird/incredible/processor/JsonKey.java
@@ -26,9 +26,12 @@ public interface JsonKey {
     String CLOUD_UPLOAD_RETRY_COUNT = "CLOUD_UPLOAD_RETRY_COUNT";
     String PRIVATE_CLOUD_STORAGE_SECRET = "PRIVATE_CLOUD_STORAGE_SECRET";
     String PRIVATE_CLOUD_STORAGE_KEY = "PRIVATE_CLOUD_STORAGE_KEY";
+
+    String CLOUD_STORAGE_ENDPOINT = "CLOUD_STORAGE_ENDPOINT";
     String AZURE="azure";
     String AWS="aws";
 
+    String OCI="oci";
     String GCP="gcloud";
     String SLUG ="sunbird_cert_slug";
     String ACCESS_CODE_LENGTH = "ACCESS_CODE_LENGTH";
@@ -125,4 +128,6 @@ public interface JsonKey {
     String QRCODE_IMAGE = "qrCodeImage";
     String EXPIRY_DATE = "expiryDate";
     String ISSUER_NAME = "issuerName";
+
+
 }

--- a/cert-processor/src/main/java/org/sunbird/incredible/processor/store/AwsStore.java
+++ b/cert-processor/src/main/java/org/sunbird/incredible/processor/store/AwsStore.java
@@ -62,7 +62,9 @@ public class AwsStore extends CloudStore {
         if (StringUtils.isNotBlank(awsStoreConfig.getType())) {
             String storageKey = awsStoreConfig.getAwsStoreConfig().getAccount();
             String storageSecret = awsStoreConfig.getAwsStoreConfig().getKey();
-            StorageConfig storageConfig = new StorageConfig(awsStoreConfig.getType(), storageKey, storageSecret);
+            scala.Option<String> storageEndpoint = scala.Option.apply("");
+            scala.Option<String> storageRegion = scala.Option.apply("");
+            StorageConfig storageConfig = new StorageConfig(awsStoreConfig.getType(), storageKey, storageSecret,storageEndpoint,storageRegion);
             logger.info("StorageParams:init:all storage params initialized for aws block");
             storageService = StorageServiceFactory.getStorageService(storageConfig);
             cloudStorage = new CloudStorage(storageService);

--- a/cert-processor/src/main/java/org/sunbird/incredible/processor/store/AzureStore.java
+++ b/cert-processor/src/main/java/org/sunbird/incredible/processor/store/AzureStore.java
@@ -62,7 +62,9 @@ public class AzureStore extends CloudStore {
         if (StringUtils.isNotBlank(azureStoreConfig.getType())) {
             String storageKey = azureStoreConfig.getAzureStoreConfig().getAccount();
             String storageSecret = azureStoreConfig.getAzureStoreConfig().getKey();
-            StorageConfig storageConfig = new StorageConfig(azureStoreConfig.getType(), storageKey, storageSecret);
+            scala.Option<String> storageEndpoint = scala.Option.apply("");
+            scala.Option<String> storageRegion = scala.Option.apply("");
+            StorageConfig storageConfig = new StorageConfig(azureStoreConfig.getType(), storageKey, storageSecret,storageEndpoint,storageRegion);
             logger.info("StorageParams:init:all storage params initialized for azure block");
             storageService = StorageServiceFactory.getStorageService(storageConfig);
             cloudStorage = new CloudStorage(storageService);

--- a/cert-processor/src/main/java/org/sunbird/incredible/processor/store/GcpStore.java
+++ b/cert-processor/src/main/java/org/sunbird/incredible/processor/store/GcpStore.java
@@ -59,7 +59,9 @@ public class GcpStore extends CloudStore {
         if (StringUtils.isNotBlank(gcpStoreConfig.getType())) {
             String storageKey = gcpStoreConfig.getGcpStoreConfig().getAccount();
             String storageSecret = gcpStoreConfig.getGcpStoreConfig().getKey();
-            StorageConfig storageConfig = new StorageConfig(gcpStoreConfig.getType(), storageKey, storageSecret);
+            scala.Option<String> storageEndpoint = scala.Option.apply("");
+            scala.Option<String> storageRegion = scala.Option.apply("");
+            StorageConfig storageConfig = new StorageConfig(gcpStoreConfig.getType(), storageKey, storageSecret,storageEndpoint,storageRegion);
             logger.info("StorageParams:init:all storage params initialized for gcp block");
             storageService = StorageServiceFactory.getStorageService(storageConfig);
             cloudStorage = new CloudStorage(storageService);

--- a/cert-processor/src/main/java/org/sunbird/incredible/processor/store/OciStore.java
+++ b/cert-processor/src/main/java/org/sunbird/incredible/processor/store/OciStore.java
@@ -1,0 +1,79 @@
+package org.sunbird.incredible.processor.store;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sunbird.cloud.storage.BaseStorageService;
+import org.sunbird.cloud.storage.factory.StorageConfig;
+import org.sunbird.cloud.storage.factory.StorageServiceFactory;
+
+import java.io.File;
+
+/**
+ * used to upload or downloads files to aws
+ */
+public class AwsStore extends CloudStore {
+
+    private StoreConfig awsStoreConfig;
+
+    private Logger logger = LoggerFactory.getLogger(AwsStore.class);
+
+    private BaseStorageService storageService = null;
+
+    private CloudStorage cloudStorage = null;
+
+    private int retryCount = 0;
+
+    public AwsStore(StoreConfig awsStoreConfig) {
+        this.awsStoreConfig = awsStoreConfig;
+        retryCount = Integer.parseInt(awsStoreConfig.getCloudRetryCount());
+        init();
+    }
+
+
+    @Override
+    public String upload(File file, String path) {
+        String uploadPath = getPath(path);
+        return cloudStorage.uploadFile(awsStoreConfig.getAwsStoreConfig().getContainerName(), uploadPath, file, false, retryCount);
+    }
+
+    @Override
+    public void download(String fileName, String localPath) {
+        cloudStorage.downloadFile(awsStoreConfig.getAwsStoreConfig().getContainerName(), fileName, localPath, false);
+    }
+
+    private String getPath(String path) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(path);
+        if (StringUtils.isNotBlank(awsStoreConfig.getAwsStoreConfig().getPath())) {
+            stringBuilder.append(awsStoreConfig.getAwsStoreConfig().getPath() + "/");
+        }
+        return stringBuilder.toString();
+    }
+
+    @Override
+    public String getPublicLink(File file, String uploadPath) {
+        String path = getPath(uploadPath);
+        return cloudStorage.upload(awsStoreConfig.getAwsStoreConfig().getContainerName(), path, file, false, retryCount);
+    }
+
+    @Override
+    public void init() {
+        if (StringUtils.isNotBlank(awsStoreConfig.getType())) {
+            String storageKey = awsStoreConfig.getAwsStoreConfig().getAccount();
+            String storageSecret = awsStoreConfig.getAwsStoreConfig().getKey();
+            StorageConfig storageConfig = new StorageConfig(awsStoreConfig.getType(), storageKey, storageSecret);
+            logger.info("StorageParams:init:all storage params initialized for aws block");
+            storageService = StorageServiceFactory.getStorageService(storageConfig);
+            cloudStorage = new CloudStorage(storageService);
+        } else {
+            logger.error("StorageParams:init:provided cloud store type doesn't match supported storage devices:".concat(awsStoreConfig.getType()));
+        }
+
+    }
+
+    @Override
+    public void close(){
+        cloudStorage.closeConnection();
+    }
+}

--- a/cert-processor/src/main/java/org/sunbird/incredible/processor/store/OciStore.java
+++ b/cert-processor/src/main/java/org/sunbird/incredible/processor/store/OciStore.java
@@ -10,13 +10,13 @@ import org.sunbird.cloud.storage.factory.StorageServiceFactory;
 import java.io.File;
 
 /**
- * used to upload or downloads files to aws
+ * used to upload or downloads files to oci
  */
-public class AwsStore extends CloudStore {
+public class OciStore extends CloudStore {
 
-    private StoreConfig awsStoreConfig;
+    private StoreConfig ociStoreConfig;
 
-    private Logger logger = LoggerFactory.getLogger(AwsStore.class);
+    private Logger logger = LoggerFactory.getLogger(OciStore.class);
 
     private BaseStorageService storageService = null;
 
@@ -24,9 +24,9 @@ public class AwsStore extends CloudStore {
 
     private int retryCount = 0;
 
-    public AwsStore(StoreConfig awsStoreConfig) {
-        this.awsStoreConfig = awsStoreConfig;
-        retryCount = Integer.parseInt(awsStoreConfig.getCloudRetryCount());
+    public OciStore(StoreConfig ociStoreConfig) {
+        this.ociStoreConfig = ociStoreConfig;
+        retryCount = Integer.parseInt(ociStoreConfig.getCloudRetryCount());
         init();
     }
 
@@ -34,19 +34,19 @@ public class AwsStore extends CloudStore {
     @Override
     public String upload(File file, String path) {
         String uploadPath = getPath(path);
-        return cloudStorage.uploadFile(awsStoreConfig.getAwsStoreConfig().getContainerName(), uploadPath, file, false, retryCount);
+        return cloudStorage.uploadFile(ociStoreConfig.getOciStoreConfig().getContainerName(), uploadPath, file, false, retryCount);
     }
 
     @Override
     public void download(String fileName, String localPath) {
-        cloudStorage.downloadFile(awsStoreConfig.getAwsStoreConfig().getContainerName(), fileName, localPath, false);
+        cloudStorage.downloadFile(ociStoreConfig.getOciStoreConfig().getContainerName(), fileName, localPath, false);
     }
 
     private String getPath(String path) {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(path);
-        if (StringUtils.isNotBlank(awsStoreConfig.getAwsStoreConfig().getPath())) {
-            stringBuilder.append(awsStoreConfig.getAwsStoreConfig().getPath() + "/");
+        if (StringUtils.isNotBlank(ociStoreConfig.getOciStoreConfig().getPath())) {
+            stringBuilder.append(ociStoreConfig.getOciStoreConfig().getPath() + "/");
         }
         return stringBuilder.toString();
     }
@@ -54,20 +54,22 @@ public class AwsStore extends CloudStore {
     @Override
     public String getPublicLink(File file, String uploadPath) {
         String path = getPath(uploadPath);
-        return cloudStorage.upload(awsStoreConfig.getAwsStoreConfig().getContainerName(), path, file, false, retryCount);
+        return cloudStorage.upload(ociStoreConfig.getOciStoreConfig().getContainerName(), path, file, false, retryCount);
     }
 
     @Override
     public void init() {
-        if (StringUtils.isNotBlank(awsStoreConfig.getType())) {
-            String storageKey = awsStoreConfig.getAwsStoreConfig().getAccount();
-            String storageSecret = awsStoreConfig.getAwsStoreConfig().getKey();
-            StorageConfig storageConfig = new StorageConfig(awsStoreConfig.getType(), storageKey, storageSecret);
-            logger.info("StorageParams:init:all storage params initialized for aws block");
+        if (StringUtils.isNotBlank(ociStoreConfig.getType())) {
+            String storageKey = ociStoreConfig.getOciStoreConfig().getAccount();
+            String storageSecret = ociStoreConfig.getOciStoreConfig().getKey();
+            scala.Option<String> storageEndpoint = scala.Option.apply(ociStoreConfig.getOciStoreConfig().getEndpoint());
+            scala.Option<String> storageRegion = scala.Option.apply("");
+            StorageConfig storageConfig = new StorageConfig(ociStoreConfig.getType(), storageKey, storageSecret,storageEndpoint,storageRegion);
+            logger.info("StorageParams:init:all storage params initialized for oci block");
             storageService = StorageServiceFactory.getStorageService(storageConfig);
             cloudStorage = new CloudStorage(storageService);
         } else {
-            logger.error("StorageParams:init:provided cloud store type doesn't match supported storage devices:".concat(awsStoreConfig.getType()));
+            logger.error("StorageParams:init:provided cloud store type doesn't match supported storage devices:".concat(ociStoreConfig.getType()));
         }
 
     }

--- a/cert-processor/src/main/java/org/sunbird/incredible/processor/store/OciStoreConfig.java
+++ b/cert-processor/src/main/java/org/sunbird/incredible/processor/store/OciStoreConfig.java
@@ -1,0 +1,64 @@
+package org.sunbird.incredible.processor.store;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+public class AwsStoreConfig  {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    private String containerName;
+
+    private String path;
+
+    private String account;
+
+    private String key;
+
+    public AwsStoreConfig() {
+    }
+
+    public String getContainerName() {
+        return containerName;
+    }
+
+    public void setContainerName(String containerName) {
+        this.containerName = containerName;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+
+    public void setAccount(String account) {
+        this.account = account;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+
+    @Override
+    public String toString() {
+        String stringRep = null;
+        try {
+            stringRep = mapper.writeValueAsString(this);
+        } catch (JsonProcessingException jpe) {
+        }
+        return stringRep;
+    }
+}

--- a/cert-processor/src/main/java/org/sunbird/incredible/processor/store/OciStoreConfig.java
+++ b/cert-processor/src/main/java/org/sunbird/incredible/processor/store/OciStoreConfig.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 
-public class AwsStoreConfig  {
+public class OciStoreConfig {
 
     private ObjectMapper mapper = new ObjectMapper();
 
@@ -16,7 +16,9 @@ public class AwsStoreConfig  {
 
     private String key;
 
-    public AwsStoreConfig() {
+    private String endpoint;
+
+    public OciStoreConfig() {
     }
 
     public String getContainerName() {
@@ -49,6 +51,14 @@ public class AwsStoreConfig  {
 
     public void setKey(String key) {
         this.key = key;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
     }
 
 

--- a/cert-processor/src/main/java/org/sunbird/incredible/processor/store/StoreConfig.java
+++ b/cert-processor/src/main/java/org/sunbird/incredible/processor/store/StoreConfig.java
@@ -18,6 +18,8 @@ public class StoreConfig {
 
     private AwsStoreConfig awsStoreConfig;
 
+    private OciStoreConfig ociStoreConfig;
+
     private GcpStoreConfig gcpStoreConfig;
 
     private StoreConfig() {
@@ -34,11 +36,14 @@ public class StoreConfig {
         } else if (storeParams.containsKey(JsonKey.GCP)) {
             GcpStoreConfig gcpStoreConfig = mapper.convertValue(storeParams.get(JsonKey.GCP), GcpStoreConfig.class);
             setGcpStoreConfig(gcpStoreConfig);
+        } else if (storeParams.containsKey(JsonKey.OCI)) {
+            OciStoreConfig ociStoreConfig = mapper.convertValue(storeParams.get(JsonKey.OCI), OciStoreConfig.class);
+            setOciStoreConfig(ociStoreConfig);
         }
     }
 
     public boolean isCloudStore() {
-        return (azureStoreConfig != null || awsStoreConfig != null || gcpStoreConfig != null);
+        return (azureStoreConfig != null || awsStoreConfig != null || gcpStoreConfig != null || ociStoreConfig != null);
     }
 
     public String getContainerName() {
@@ -49,6 +54,8 @@ public class StoreConfig {
             containerName = awsStoreConfig.getContainerName();
         } else if (JsonKey.GCP.equals(getType())) {
             containerName = gcpStoreConfig.getContainerName();
+        } else if (JsonKey.OCI.equals(getType())) {
+            containerName = ociStoreConfig.getContainerName();
         }
         return containerName;
     }
@@ -85,6 +92,13 @@ public class StoreConfig {
         this.awsStoreConfig = awsStoreConfig;
     }
 
+    public OciStoreConfig getOciStoreConfig() {
+        return ociStoreConfig;
+    }
+
+    public void setOciStoreConfig(OciStoreConfig ociStoreConfig) {
+        this.ociStoreConfig = ociStoreConfig;
+    }
     public GcpStoreConfig getGcpStoreConfig() {
         return gcpStoreConfig;
     }

--- a/certificate-migration/pom.xml
+++ b/certificate-migration/pom.xml
@@ -78,8 +78,8 @@
         </dependency>
         <dependency>
             <groupId>org.sunbird</groupId>
-            <artifactId>cloud-store-sdk</artifactId>
-            <version>1.4.0</version>
+            <artifactId>cloud-store-sdk_2.11</artifactId>
+            <version>1.4.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/certificate-migration/src/main/java/org/sunbird/CloudStorage.java
+++ b/certificate-migration/src/main/java/org/sunbird/CloudStorage.java
@@ -28,11 +28,21 @@ public class CloudStorage {
         if (StringUtils.equalsIgnoreCase(cloudStoreType, "azure")) {
             String storageKey = System.getenv("AZURE_STORAGE_KEY");
             String storageSecret = System.getenv("AZURE_STORAGE_SECRET");
-            storageService = StorageServiceFactory.getStorageService(new StorageConfig(cloudStoreType, storageKey, storageSecret));
+            scala.Option<String> storageEndpoint = scala.Option.apply(""));
+            scala.Option<String> storageRegion = scala.Option.apply("");
+            storageService = StorageServiceFactory.getStorageService(new StorageConfig(cloudStoreType, storageKey, storageSecret,storageEndpoint,storageRegion));
         } else if (StringUtils.equalsIgnoreCase(cloudStoreType, "aws")) {
             String storageKey = System.getenv("cert_aws_storage_key");
             String storageSecret = System.getenv("cert_aws_storage_secret");
-            storageService = StorageServiceFactory.getStorageService(new StorageConfig(cloudStoreType, storageKey, storageSecret));
+            scala.Option<String> storageEndpoint = scala.Option.apply(""));
+            scala.Option<String> storageRegion = scala.Option.apply("");
+            storageService = StorageServiceFactory.getStorageService(new StorageConfig(cloudStoreType, storageKey, storageSecret,storageEndpoint,storageRegion));
+        }else if (StringUtils.equalsIgnoreCase(cloudStoreType, "oci")) {
+            String storageKey = System.getenv("cert_oci_storage_key");
+            String storageSecret = System.getenv("cert_oci_storage_secret");
+            scala.Option<String> storageEndpoint = scala.Option.apply(System.getenv("cert_oci_storage_endpoint"));
+            scala.Option<String> storageRegion = scala.Option.apply("");
+            storageService = StorageServiceFactory.getStorageService(new StorageConfig(cloudStoreType, storageKey, storageSecret,storageEndpoint,storageRegion));
         } else try {
             throw new Exception("ERR_INVALID_CLOUD_STORAGE Error while initialising cloud storage");
         } catch (Exception e) {


### PR DESCRIPTION
updated cloud-store-sdk: 1.4.6
added oci implementation in cloud storage invoction
As we introduced endpoint parameter, it needs to be passed during the helm install
The will be a supporting pull request to be created for the deployment.
### Type of change

Please choose appropriate options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran Build/Core/Cert
